### PR TITLE
Fix URL of jekyll in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Repository for the website [canvas.arc42.org](https://canvas.arc42.org).
 
 ## Credits
 
-Based upon [Jekyll](https://jekyllrb.org) and the [MinimalMistakes theme](https://mmistakes.github.io/minimal-mistakes/). Rendered using GitHub Pages.
+Based upon [Jekyll](https://jekyllrb.com) and the [MinimalMistakes theme](https://mmistakes.github.io/minimal-mistakes/). Rendered using GitHub Pages.
 
 ## License
 <p xmlns:cc="http://creativecommons.org/ns#" xmlns:dct="http://purl.org/dc/terms/"><a property="dct:title" rel="cc:attributionURL" href="https://canvas.arc42.org">Software Architecture Canvas</a> by <span property="cc:attributionName">Gernot Starke, Patrick Roos and arc42 Contributors</span> is licensed under <a href="http://creativecommons.org/licenses/by-sa/4.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">Attribution-ShareAlike 4.0 International<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg?ref=chooser-v1"></a></p> 


### PR DESCRIPTION
Jekyll resides under jekyll.com and not .org